### PR TITLE
Handle advising constructors invoked with `new`

### DIFF
--- a/test/constructors.js
+++ b/test/constructors.js
@@ -1,0 +1,70 @@
+(function(buster, meld) {
+"use strict";
+
+var assert, refute;
+
+assert = buster.assert;
+refute = buster.refute;
+
+var arg = 'foo';
+
+// Test fixture
+function Fixture(a) {
+	this.prop = a;
+}
+
+buster.testCase('constructors', {
+	'should advise a constructor using arround advise': function() {
+		var target, spy, ret;
+
+		target = { method: Fixture };
+		spy = this.spy();
+
+		meld.around(target, 'method', function aroundAdvice(joinpoint) {
+			var ret;
+
+			spy();
+			assert.equals(arg, joinpoint.args[0]);
+
+			ret = joinpoint.proceed();
+
+			assert(ret instanceof Fixture);
+			assert.same(Fixture, ret.constructor);
+			assert.same(arg, ret.prop);
+
+			return ret;
+		});
+
+		ret = new target.method(arg);
+
+		assert.called(spy);
+		assert(ret instanceof Fixture);
+		assert.same(Fixture, ret.constructor);
+		assert.same(arg, ret.prop);
+	},
+
+	'should advise a constructor using simple advise': function() {
+		var target, spy, ret;
+
+		target = { method: Fixture };
+		spy = this.spy();
+
+		meld.before(target, 'method', function beforeAdvice(a) {
+			spy();
+			assert.equals(arg, a);
+		});
+
+		ret = new target.method(arg);
+
+		assert.called(spy);
+		assert(ret instanceof Fixture);
+		assert.same(Fixture, ret.constructor);
+		assert.same(arg, ret.prop);
+	}
+
+});
+
+})(
+	require('buster'),
+	require('../meld')
+);


### PR DESCRIPTION
Detects a `new` constructor invocation when `this` is an instanceof the
advised function. The advised constructor is involved with the correct
context.

This functionality assumes an ES5 compatible Object.create instance is
available. The constructor property on the new instance will only be
set within an ES5 environment.
