### PR TITLE
Indicate how many time proceed() has been called

### DIFF
--- a/meld.js
+++ b/meld.js
@@ -158,7 +158,7 @@ define(function () {
 			}
 
 			function callAround(around, i, args) {
-				var proceed, joinpoint;
+				var proceed, count, proceedCount, joinpoint;
 
 				/**
 				 * Create proceed function that calls the next around advice, or
@@ -168,8 +168,18 @@ define(function () {
 				 * original arguments
 				 */
 				proceed = function (args) {
+					count++;
 					return callNext(i - 1, args);
 				};
+
+				/**
+				 * The number of times proceed() has been called
+				 */
+				proceedCount = function () {
+					return count;
+				};
+
+				count = 0;
 
 				// Joinpoint is immutable
 				joinpoint = freeze({
@@ -177,7 +187,8 @@ define(function () {
 					method: method,
 					args: args,
 					proceed: proceedCall,
-					proceedApply: proceedApply
+					proceedApply: proceedApply,
+					proceedCount: proceedCount
 				});
 
 				// Call supplied around advice function

--- a/test/around.js
+++ b/test/around.js
@@ -61,8 +61,11 @@ buster.testCase('around', {
 
 		aop.around(target, 'method', function aroundAdvice(joinpoint) {
 			// Calling joinpoint.proceed() multiple times is allowed
+			assert.same(0, joinpoint.proceedCount());
 			refute.exception(joinpoint.proceed);
+			assert.same(1, joinpoint.proceedCount());
 			refute.exception(joinpoint.proceed);
+			assert.same(2, joinpoint.proceedCount());
 		});
 
 		target.method(arg);


### PR DESCRIPTION
joinpoint.proceedCount() returns that value
