### PR TITLE
Allow weaving of methods on a host function

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Run unit tests in Node:
 
 # Changelog
 
+### 1.1.0
+
+* **Removed implicit constructor prototype advice** - to advise a constructor prototype, pass the prototype as the target instead of the constuctor.
+* Advice can be applied directly to methods on a function
+
 ### 1.0.0
 
 * **Removed browser global** - `window.meld` is no longer supported. See [this post on the cujo.js Google Group](https://groups.google.com/d/topic/cujojs/K0VGuvpYQ34/discussion) for an explanation.

--- a/meld.js
+++ b/meld.js
@@ -9,7 +9,7 @@
  * Licensed under the MIT License at:
  * http://www.opensource.org/licenses/mit-license.php
  *
- * @version 1.0.0
+ * @version 1.1.0
  */
 (function (define) {
 define(function () {
@@ -336,8 +336,6 @@ define(function () {
 		if(arguments.length < 3) {
 			return addAspectToFunction(target, pointcut);
 		} else {
-			target = getPointcutTarget(target);
-
 			if (isArray(pointcut)) {
 				remove = addAspectToAll(target, pointcut, aspect);
 
@@ -427,10 +425,6 @@ define(function () {
 				}
 			}
 		};
-	}
-
-	function getPointcutTarget(target) {
-		return typeof target == 'function' ? target.prototype||target : target;
 	}
 
 	// Create an API function for the specified advice type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "meld",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "AOP for JS with before, around, on, afterReturning, afterThrowing, after advice, and pointcut support",
 	"keywords": ["aop", "aspect", "cujo"],
 	"licenses": [

--- a/test/functions.js
+++ b/test/functions.js
@@ -47,6 +47,22 @@ buster.testCase('functions', {
 		assert.calledOnceWith(spyBefore, 1);
 		assert.calledOnceWith(spyAround, 2);
 		assert.calledOnceWith(spyAfter, 3);
+	},
+
+	'should advise a method on a function': function() {
+		var before, method, target;
+
+		function target() {}
+		method = target.method = this.spy();
+		before = this.spy();
+
+		// Advise the function method
+		meld.before(target, 'method', before);
+
+		target.method();
+
+		assert.calledOnce(before);
+		assert.calledOnce(method);
 	}
 
 

--- a/test/prototype.js
+++ b/test/prototype.js
@@ -16,7 +16,7 @@ buster.testCase('prototype', {
 		before = this.spy();
 
 		// Advise the prototype method
-		aop.before(Fixture, 'method', before);
+		aop.before(Fixture.prototype, 'method', before);
 
 		target = new Fixture();
 		target.method();


### PR DESCRIPTION
Implicit constructor prototype weaving blocked weaving methods on a host
function. That functionality has been removed in order to support weaving
of methods hosted on a function. Prototype weaving can still be achieved
by passing the constructor's prototype instead of the constructor.

Bumped version to 1.1.0 due to public API change.
