### PR TITLE
Fix npm warning: 'repositories' (plural) Not supported. Please pick one ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,10 @@
 			"url": "http://www.opensource.org/licenses/mit-license.php"
 		}
 	],
-	"repositories": [
-		{
-			"type": "git",
-			"url": "https://github.com/cujojs/meld"
-		}
-	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/cujojs/meld"
+	},
 	"bugs": "https://github.com/cujojs/meld/issues",
 	"maintainers": [
 		{


### PR DESCRIPTION
...as the 'repository' field