### PR TITLE
Fix addAspectToMatches to work also with classes

### DIFF
--- a/meld.js
+++ b/meld.js
@@ -400,18 +400,19 @@ define(function () {
 
 	function addAspectToMatches(target, pointcut, aspect) {
 		var removers = [];
+
+		let propertyNames = Object.getOwnPropertyNames(target.__proto__)
 		// Assume the pointcut is a an object with a .test() method
-		for (var p in target) {
-			// TODO: Decide whether hasOwnProperty is correct here
-			// Only apply to own properties that are functions, and match the pointcut regexp
-			if (typeof target[p] == 'function' && pointcut.test(p)) {
-				// if(object.hasOwnProperty(p) && typeof object[p] === 'function' && pointcut.test(p)) {
-				removers.push(addAspectToMethod(target, p, aspect));
-			}
+		for (var p of propertyNames) {
+				let isFunction = typeof target[p] == 'function'
+				let isMatched = pointcut.test(p)
+				if (isFunction && isMatched) {
+						removers.push(addAspectToMethod(target, p, aspect));
+				}
 		}
 
 		return createRemover(removers);
-	}
+}
 
 	function createRemover(removers) {
 		return {


### PR DESCRIPTION
Applying aspect over a class doesn't work. This is caused by the fact that the methods added to the prototypes of the ES2015 classes are not enumerable but addAspectToMatches is using for..in in order to get them.

I solved this by @mgechev suggestion and used Object.getOwnPropertyNames to get all class's methods, traverse them and check if they're function and match the pointcut.

It's my first pull request here in github so sorry if I missed anything or did something wrong in the process.